### PR TITLE
build: restrict GregTech CEu dependency to 1.x versions

### DIFF
--- a/neoforge-1.21/build.gradle
+++ b/neoforge-1.21/build.gradle
@@ -37,7 +37,7 @@ tasks.withType(ProcessResources).configureEach {
         mod_version            : mod_version,
         mod_authors            : mod_authors,
         mod_description        : mod_description,
-        gtceu_version          : gtceu_version
+        gtceu_version_range    : gtceu_version_range
     ]
     inputs.properties replaceProperties
     filesMatching(['META-INF/neoforge.mods.toml']) { expand replaceProperties }

--- a/neoforge-1.21/gradle.properties
+++ b/neoforge-1.21/gradle.properties
@@ -16,4 +16,4 @@ mod_group_id=cyb0124.greg_emitters
 mod_authors=cyb0124
 mod_description=This mod makes GregTech's emitters placeable in-world. When powered, placed emitter blocks shoot beam that transfers energy to the machine it hits.
 
-gtceu_version=1.4.6
+gtceu_version_range=[1.4.6,2.0.0)

--- a/neoforge-1.21/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge-1.21/src/main/resources/META-INF/neoforge.mods.toml
@@ -23,6 +23,6 @@ logoFile="icon.png"
 [[dependencies.${mod_id}]]
     modId="gtceu"
     mandatory=true
-    versionRange="[${gtceu_version},)"
+    versionRange="${gtceu_version_range}"
     ordering="BEFORE"
     side="BOTH"


### PR DESCRIPTION
Limit GregTech CEu Modern dependency to versions >= 1.4.6 and < 2.0.0 to prevent loading with incompatible GregTech v7.x releases which have breaking API changes.

Closes #9

#8 might also be related.